### PR TITLE
Fix TypeError in gh_public_events.py when commits are missing

### DIFF
--- a/src/gitxray/include/gh_public_events.py
+++ b/src/gitxray/include/gh_public_events.py
@@ -87,7 +87,9 @@ def log_events(events, gx_output, for_repository=False):
 
         # https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#pushevent
         elif etype == "PushEvent":
-            logging_func(f"{ts}: {actor}pushed a total of {len(payload.get('commits'))} commits from: [{payload.get('ref')}]", rtype="90d_events")
+            commits = payload.get('commits')
+            if commits is None: commits = []
+            logging_func(f"{ts}: {actor}pushed a total of {len(commits)} commits from: [{payload.get('ref')}]", rtype="90d_events")
 
         # https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#releaseevent
         elif etype == "ReleaseEvent":


### PR DESCRIPTION
This PR fixes a TypeError: object of type 'NoneType' has no len() that occurs when processing PushEvent payloads where the commits key is missing or None.

Changes:
Added a check in 
src/gitxray/include/gh_public_events.py
 to handle cases where payload.get('commits') returns None.
Defaults commits to an empty list [] to prevent len() from failing.

Verification:
Verified with a reproduction script simulating a PushEvent with missing commits.
Verified by running gitxray against the repository that caused the crash (ThemeHackers/ssf).